### PR TITLE
Fix of fix darwin build.

### DIFF
--- a/src/ctests/attach2.c
+++ b/src/ctests/attach2.c
@@ -22,6 +22,8 @@
 #include <sys/ptrace.h>
 #include <sys/wait.h>
 
+#include "darwin-common.h"
+
 #include "papi.h"
 #include "papi_test.h"
 

--- a/src/ctests/attach2.c
+++ b/src/ctests/attach2.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <limits.h>
+#include <sys/types.h>
 #include <sys/ptrace.h>
 #include <sys/wait.h>
 

--- a/src/ctests/attach3.c
+++ b/src/ctests/attach3.c
@@ -23,6 +23,8 @@
 #include <sys/ptrace.h>
 #include <sys/wait.h>
 
+#include "darwin-common.h"
+
 #include "papi.h"
 #include "papi_test.h"
 

--- a/src/ctests/attach3.c
+++ b/src/ctests/attach3.c
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include <limits.h>
+#include <sys/types.h>
 #include <sys/ptrace.h>
 #include <sys/wait.h>
 

--- a/src/ctests/attach_validate.c
+++ b/src/ctests/attach_validate.c
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <limits.h>
+#include <sys/types.h>
 #include <sys/ptrace.h>
 #include <sys/wait.h>
 

--- a/src/ctests/attach_validate.c
+++ b/src/ctests/attach_validate.c
@@ -9,6 +9,8 @@
 #include <sys/ptrace.h>
 #include <sys/wait.h>
 
+#include "darwin-common.h"
+
 #include "papi.h"
 #include "papi_test.h"
 

--- a/src/ctests/multiattach.c
+++ b/src/ctests/multiattach.c
@@ -23,6 +23,8 @@
 #include <sys/wait.h>
 #include <inttypes.h>
 
+#include "darwin-common.h"
+
 #include "papi.h"
 #include "papi_test.h"
 

--- a/src/ctests/multiattach.c
+++ b/src/ctests/multiattach.c
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/types.h>
 #include <sys/ptrace.h>
 #include <sys/wait.h>
 #include <inttypes.h>

--- a/src/ctests/multiattach2.c
+++ b/src/ctests/multiattach2.c
@@ -23,6 +23,8 @@
 #include <sys/ptrace.h>
 #include <sys/wait.h>
 
+#include "darwin-common.h"
+
 #include "papi.h"
 #include "papi_test.h"
 

--- a/src/ctests/multiattach2.c
+++ b/src/ctests/multiattach2.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <inttypes.h>
+#include <sys/types.h>
 #include <sys/ptrace.h>
 #include <sys/wait.h>
 

--- a/src/ctests/zero_attach.c
+++ b/src/ctests/zero_attach.c
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <sys/types.h>
 #include <sys/ptrace.h>
 #include <sys/wait.h>
 

--- a/src/ctests/zero_attach.c
+++ b/src/ctests/zero_attach.c
@@ -21,6 +21,8 @@
 #include <sys/ptrace.h>
 #include <sys/wait.h>
 
+#include "darwin-common.h"
+
 #include "papi.h"
 #include "papi_test.h"
 

--- a/src/darwin-common.c
+++ b/src/darwin-common.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <sys/utsname.h>
+#include <sys/sysctl.h>
 
 #include <time.h>
 #include <sys/time.h>

--- a/src/darwin-common.h
+++ b/src/darwin-common.h
@@ -15,6 +15,10 @@ mygettid( void )
   return pthread_self();
 }
 
+#define PTRACE_TRACEME PT_TRACE_ME
+#define PTRACE_CONT PT_CONTINUE
+#define PTRACE_ATTACH PT_ATTACH
+
 long long _darwin_get_real_cycles( void );
 long long _darwin_get_virt_usec_times( void );
 long long _darwin_get_real_usec_gettimeofday( void );

--- a/src/darwin-common.h
+++ b/src/darwin-common.h
@@ -1,6 +1,8 @@
 #ifndef _DARWIN_COMMON_H
 #define _DARWIN_COMMON_H
 
+#include <pthread.h>
+
 #define min(x, y) ({				\
 	typeof(x) _min1 = (x);			\
 	typeof(y) _min2 = (y);			\

--- a/src/darwin-memory.c
+++ b/src/darwin-memory.c
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <errno.h>
+#include <sys/sysctl.h>
 
 #include "papi.h"
 #include "papi_internal.h"


### PR DESCRIPTION
Dear Geoffrey,

for my work on a project for the Zuse Institute Berlin I came across your papi darwin build fix.

This PR represents my additional fixes in order to compile papi on my system: macOS Catalina 10.15.6 (19G2021)

It mostly consists of missing header includes and the redefinition of ptrace symbols. 

Maybe this will help someone to run papi on his macOS machine in the future. 